### PR TITLE
Using the current release unicorn

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -9,7 +9,7 @@ namespace :unicorn do
   set_default :unicorn_env,       -> { fetch(:rails_env) == 'development' ? 'development' : 'deployment' }
   set_default :unicorn_config,    -> { "#{deploy_to}/#{current_path}/config/unicorn.rb" }
   set_default :unicorn_pid,       -> { "#{deploy_to}/#{current_path}/tmp/pids/unicorn.pid"  }
-  set_default :unicorn_cmd,       -> { "#{bundle_prefix} unicorn" }
+  set_default :unicorn_cmd,       -> { "#{deploy_to}/#{current_path}/#{bundle_prefix} unicorn" }
   set_default :unicorn_restart_sleep_time, -> { 2 }
   set_default :bundle_gemfile,    -> { "#{deploy_to}/#{current_path}/Gemfile" }
 


### PR DESCRIPTION
Hi @scarfacedeb!

 I was with this error in production:

`I, [2015-10-01T01:53:10.386333 #21194]  INFO -- : executing ["/www/app/releases/61/vendor/bundle/ruby/2.1.0/bin/unicorn", "-c", "/www/app/current/config/unicorn.rb", "-E", "production", "-D", {13=>#<Kgio::UNIXServer:/tmp/unicorn.sock>}] (in /www/app/releases/62)
/www/app/releases/61/vendor/bundle/ruby/2.1.0/gems/unicorn-4.6.3/lib/unicorn/http_server.rb:452:in 'exec': No such file or directory - /www/app/releases/61/vendor/bundle/ruby/2.1.0/bin/unicorn (Errno::ENOENT)`

This error occurred after deploying the version v62, but mina was trying to use the unicorn of version 61.Changing the `unicorn_cmd` fixed it.

Until now, I don't know what I did/changed to start this error. Any clue?

Anyway, do you think this PR can be useful to avoid further errors?