### PR TITLE
Do not require 'mina/rails'

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -1,5 +1,5 @@
 require "mina/bundler"
-require "mina/rails"
+require "mina/deploy"
 require "mina/unicorn/utility"
 
 namespace :unicorn do


### PR DESCRIPTION
This avoids ending up with Rails vars when not using Rails. It still honors 'rails_env' for setting 'unicorn_env' if it is present. 

Fixes #23