### PR TITLE
Use bundle_prefix for unicorn_cmd if available

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -9,7 +9,7 @@ namespace :unicorn do
   set :unicorn_env,       -> { fetch(:rails_env) == "development" ? "development" : "deployment" }
   set :unicorn_config,    -> { "#{fetch(:current_path)}/config/unicorn.rb" }
   set :unicorn_pid,       -> { "#{fetch(:current_path)}/tmp/pids/unicorn.pid" }
-  set :unicorn_cmd,       -> { "#{fetch(:bundle_prefix)} unicorn" }
+  set :unicorn_cmd,       -> { "#{fetch(:bundle_prefix, "#{fetch(:bundle_bin)} exec")} unicorn" }
   set :unicorn_restart_sleep_time, -> { 2 }
   set :bundle_gemfile,    -> { "#{fetch(:current_path)}/Gemfile" }
 


### PR DESCRIPTION
Commit 7cc5272 removed mina/rails dependency, so 'bundle_prefix' could not be
set. Use it if available, otherwise default to 'bundle exec'.