### PR TITLE
Remove :environment dependency

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -14,22 +14,22 @@ namespace :unicorn do
   set :bundle_gemfile,    -> { "#{fetch(:current_path)}/Gemfile" }
 
   desc "Start Unicorn master process"
-  task start: :environment do
+  task start: :remote_environment do
     command start_unicorn
   end
 
   desc "Stop Unicorn"
-  task stop: :environment do
+  task stop: :remote_environment do
     command kill_unicorn("QUIT")
   end
 
   desc "Immediately shutdown Unicorn"
-  task shutdown: :environment do
+  task shutdown: :remote_environment do
     command kill_unicorn("TERM")
   end
 
   desc "Restart unicorn service"
-  task restart: :environment do
+  task restart: :remote_environment do
     command restart_unicorn
   end
 end


### PR DESCRIPTION
Mina recently deprecated the use of the `:environment` task. All tasks should remove that dependency and use `:remote_environment` or `:local_environment` if needed. In this case, there is no need to use any of these tasks at all. 

See also https://github.com/mina-deploy/mina/issues/569