### PR TITLE
Fix deprecation warnings from Mina

### DIFF
--- a/lib/mina/unicorn/tasks.rb
+++ b/lib/mina/unicorn/tasks.rb
@@ -13,17 +13,17 @@ namespace :unicorn do
   set :bundle_gemfile,    -> { "#{fetch(:current_path)}/Gemfile" }
 
   desc "Start Unicorn master process"
-  task start: :remote_environment do
+  task :start do
     command start_unicorn
   end
 
   desc "Stop Unicorn"
-  task stop: :remote_environment do
+  task :stop do
     command kill_unicorn("QUIT")
   end
 
   desc "Immediately shutdown Unicorn"
-  task shutdown: :remote_environment do
+  task :shutdown do
     command kill_unicorn("TERM")
   end
 

--- a/lib/mina/unicorn/version.rb
+++ b/lib/mina/unicorn/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Unicorn
-    VERSION = "2.0.0"
+    VERSION = "3.0.0"
   end
 end

--- a/mina-unicorn.gemspec
+++ b/mina-unicorn.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = []
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "mina", "~> 1.0"
+  spec.add_dependency "mina", ">= 1.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
According to the mina changelogs `task: :environment` is no longer valid.

ref: https://github.com/mina-deploy/mina/blob/master/CHANGELOG.md#v123-2017-11-22

I made a full version bump since this change is only backwards compatible to Mina 1.1 as per the changelog here: https://github.com/mina-deploy/mina/blob/master/CHANGELOG.md#v110-2017-09-29